### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=mCube <service@mcubemems.com>
 sentence=Driver for the MC3610 Accelerometer
 paragraph=Driver for the MC3610 Accelerometer
 category=Sensors
-url=*
+url=https://github.com/mcubemems/Accelerometer_MC3610
 architectures=*


### PR DESCRIPTION
A invalid url field results in an apparently clickable "More info" link in Library Manager that does nothing.